### PR TITLE
fixed bug with `customfn`, exposed `getPathWithArgs` for fallback in the `customfn` when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 This file documents all notable changes to the project.
 
+## [1.0.9] - 2025-10-06
+### Fixed
+- Fixed bug where `customFn` was accidentally sent as initial cache object, which caused exceptions in React apps when developers tried adding `customFn` to `pathgen` and React attempted to validate if it was a React function component.
+
+### Added
+- Exposed the default `getPathWithArgs` utility function, allowing users to implement a custom function and fallback to the original behavior when needed.
+
 ## [1.0.5] - 2025-01-07
 ### Changed
 - Enhanced functionality to return actual interface primitive types when a `customFn` is provided by the user.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "object-path-generator",
   "description": "A lightweight library to generate object paths",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "scripts": {
     "build": "tsc && yarn run lint",
     "lint": "eslint src",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-import { pathgen } from './pathGen/pathGen';
-
-export { pathgen };
+export { pathgen } from './pathGen/pathGen';
+export * from './pathGen/pathGen.utils';

--- a/src/pathGen/pathGen.ts
+++ b/src/pathGen/pathGen.ts
@@ -1,3 +1,5 @@
+import { getPathWithArgs } from './pathGen.utils';
+
 type DeepRequired<T = any> = {
   [K in keyof T]-?: NonNullable<T[K]> extends Function
     ? NonNullable<T[K]>
@@ -29,23 +31,7 @@ const pathgenInner = (
       if (customFn) {
         return customFn(path, ...options);
       }
-      let finalPath = path;
-      if (options.length > 0) {
-        const finalOptions = options.flatMap((option) => {
-          if (Array.isArray(option)) {
-            return option;
-          } else if (typeof option === 'object') {
-            return Object.entries(option).map(
-              ([key, value]) => `${key}-${value}`,
-            );
-          } else {
-            return [option];
-          }
-        });
-
-        finalPath = [finalPath, ...finalOptions].join(' ');
-      }
-      return finalPath;
+      return getPathWithArgs(path, options);
     },
     {
       get(_target, prop: string) {
@@ -65,4 +51,4 @@ export const pathgen = <T = any, R = undefined>(
 ): PathGenElements<
   DeepRequired<T>,
   R extends undefined ? (typeof customFn extends undefined ? string : R) : R
-> => pathgenInner(root, root, customFn, customFn) as any;
+> => pathgenInner(root, root, customFn) as any;

--- a/src/pathGen/pathGen.utils.ts
+++ b/src/pathGen/pathGen.utils.ts
@@ -1,0 +1,17 @@
+export const getPathWithArgs = (path: string, args: any[]) => {
+  let finalPath = path;
+  if (args.length > 0) {
+    const finalOptions = args.flatMap((option) => {
+      if (Array.isArray(option)) {
+        return option;
+      } else if (typeof option === 'object') {
+        return Object.entries(option).map(([key, value]) => `${key}-${value}`);
+      } else {
+        return [option];
+      }
+    });
+
+    finalPath = [finalPath, ...finalOptions].join(' ');
+  }
+  return finalPath;
+};


### PR DESCRIPTION

### Fixed
- Fixed bug where `customFn` was accidentally sent as initial cache object, which caused exceptions in React apps when developers tried adding `customFn` to `pathgen` and React attempted to validate if it was a React function component.

### Added
- Exposed the default `getPathWithArgs` utility function, allowing users to implement a custom function and fallback to the original behavior when needed.